### PR TITLE
Fixes some C++20 issues found when running subspace rpc tests

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,5 @@
 bazel-cocpp
+_deps
+build
+lib
+bin

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "coroutines",
-    version = "3.2.0",
+    version = "3.2.1",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "coroutines",
-    version = "3.1.0",
+    version = "3.2.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 24,
+  "lockFileVersion": 26,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -14,22 +14,30 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
     "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
     "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
     "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
+    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
     "https://bcr.bazel.build/modules/apple_support/1.22.1/MODULE.bazel": "90bd1a660590f3ceffbdf524e37483094b29352d85317060b2327fff8f3f4458",
-    "https://bcr.bazel.build/modules/apple_support/1.23.1/MODULE.bazel": "53763fed456a968cf919b3240427cf3a9d5481ec5466abc9d5dc51bc70087442",
-    "https://bcr.bazel.build/modules/apple_support/1.23.1/source.json": "d888b44312eb0ad2c21a91d026753f330caa48a25c9b2102fae75eb2b0dcfdd2",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
     "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
     "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
-    "https://bcr.bazel.build/modules/bazel_features/1.30.0/source.json": "b07e17f067fe4f69f90b03b36ef1e08fe0d1f3cac254c1241a1818773e3423bc",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
+    "https://bcr.bazel.build/modules/bazel_features/1.42.1/source.json": "fcd4396b2df85f64f2b3bb436ad870793ecf39180f1d796f913cc9276d355309",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
@@ -43,10 +51,11 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
     "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/MODULE.bazel": "72997b29dfd95c3fa0d0c48322d05590418edef451f8db8db5509c57875fb4b7",
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/MODULE.bazel": "a35d9561b3fc5b18797c330793e99e3b834a473d5fbd3d7d7634aafc9bdb6f8f",
+    "https://bcr.bazel.build/modules/buildozer/8.5.1/source.json": "e3386e6ff4529f2442800dee47ad28d3e6487f36a1f75ae39ae56c70f0cd2fbd",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -56,8 +65,11 @@
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
@@ -72,12 +84,13 @@
     "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
-    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
-    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
-    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
+    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.13.6/MODULE.bazel": "2d746fda559464b253b2b2e6073cb51643a2ac79009ca02100ebbc44b4548656",
@@ -89,10 +102,12 @@
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/source.json": "a8ae7c09533bf67f9f6e5122d884d5741600b09d78dca6fc0f2f8d2ee0c2d957",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
@@ -101,37 +116,36 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
     "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
     "https://bcr.bazel.build/modules/rules_cc/0.1.4/MODULE.bazel": "bb03a452a7527ac25a7518fb86a946ef63df860b9657d8323a0c50f8504fb0b9",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
     "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
     "https://bcr.bazel.build/modules/rules_cc/0.2.16/MODULE.bazel": "9242fa89f950c6ef7702801ab53922e99c69b02310c39fb6e62b2bd30df2a1d4",
-    "https://bcr.bazel.build/modules/rules_cc/0.2.16/source.json": "d03d5cde49376d87e14ec14b666c56075e5e3926930327fd5d0484a1ff2ac1cc",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/MODULE.bazel": "1849602c86cb60da8613d2de887f9566a6d354a6df6d7009f9d04a14402f9a84",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.17/source.json": "3832f45d145354049137c0090df04629d9c2b5493dc5c2bf46f1834040133a07",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
-    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
-    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
-    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
-    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/MODULE.bazel": "717717ed40cc69994596a45aec6ea78135ea434b8402fb91b009b9151dd65615",
-    "https://bcr.bazel.build/modules/rules_java/8.14.0/source.json": "8a88c4ca9e8759da53cddc88123880565c520503321e2566b4e33d0287a3d4bc",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
-    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
-    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
@@ -145,8 +159,8 @@
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
-    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
@@ -155,18 +169,29 @@
     "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.34.0/MODULE.bazel": "1d623d026e075b78c9fde483a889cda7996f5da4f36dffb24c246ab30f06513a",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
     "https://bcr.bazel.build/modules/rules_python/1.5.1/MODULE.bazel": "acfe65880942d44a69129d4c5c3122d57baaf3edf58ae5a6bd4edea114906bf5",
-    "https://bcr.bazel.build/modules/rules_python/1.5.1/source.json": "aa903e1bcbdfa1580f2b8e2d55100b7c18bc92d779ebb507fec896c75635f7bd",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
-    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
-    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
@@ -178,11 +203,11 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "rL/34P1aFDq2GqVC2zCFgQ8nTuOC6ziogocpvG50Qz8=",
+        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
+        ],
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -230,23 +255,185 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
+      }
+    },
+    "@@rules_python+//python/extensions:config.bzl%config": {
+      "general": {
+        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
+        ],
+        "generatedRepoSpecs": {
+          "rules_python_internal": {
+            "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
+            "attributes": {
+              "transition_setting_generators": {},
+              "transition_settings": []
+            }
+          },
+          "pypi__build": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+              "sha256": "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__click": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+              "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__colorama": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__importlib_metadata": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+              "sha256": "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__installer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+              "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__more_itertools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/50/e2/8e10e465ee3987bb7c9ab69efb91d867d93959095f4807db102d07995d94/more_itertools-10.2.0-py3-none-any.whl",
+              "sha256": "686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__packaging": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+              "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pep517": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/25/6e/ca4a5434eb0e502210f591b97537d322546e4833dcb4d470a48c375c5540/pep517-0.13.1-py3-none-any.whl",
+              "sha256": "31b206f67165b3536dd577c5c3f1518e8fbaf38cbc57efff8369a392feff1721",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+              "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+              "sha256": "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pyproject_hooks": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+              "sha256": "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__setuptools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl",
+              "sha256": "c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__tomli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__wheel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+              "sha256": "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__zipp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/da/55/a03fd7240714916507e1fcf7ae355bd9d9ed2e6db492595f1a67f61681be/zipp-3.18.2-py3-none-any.whl",
+              "sha256": "dce197b859eb796242b0622af1b8beb0a722d52aa2f57133ead08edd5bf5374e",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          }
+        }
       }
     },
     "@@rules_python+//python/uv:uv.bzl%uv": {
       "general": {
-        "bzlTransitiveDigest": "8vT1ddXtljNxYD0tJkksqzeKE6xqx4Ix+tXthAppjTI=",
-        "usagesDigest": "WYhzIw9khRBy34H1GxV5+fI1yi07O90NmCXosPUdHWQ=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
         "generatedRepoSpecs": {
           "uv": {
             "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
@@ -266,19 +453,7 @@
               "toolchain_target_settings": {}
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_python+",
-            "bazel_tools",
-            "bazel_tools"
-          ],
-          [
-            "rules_python+",
-            "platforms",
-            "platforms"
-          ]
-        ]
+        }
       }
     }
   },

--- a/co/coroutine_cpp20.cc
+++ b/co/coroutine_cpp20.cc
@@ -229,7 +229,7 @@ void Scheduler::WaitForFd(Coroutine* coroutine, int fd, uint32_t event_mask,
   }
 
   // Add coroutine to waiting list for this FD.
-  bool fd_already_tracked = waiting_fds_.count(fd) > 0;
+  [[maybe_unused]] bool fd_already_tracked = waiting_fds_.count(fd) > 0;
   auto& wait_list = waiting_fds_[fd];
   if (std::find(wait_list.begin(), wait_list.end(), coroutine) == wait_list.end()) {
     wait_list.push_back(coroutine);

--- a/co/coroutine_cpp20.cc
+++ b/co/coroutine_cpp20.cc
@@ -489,7 +489,8 @@ void Scheduler::ResumeCoroutine(Coroutine* coroutine, int value) {
     }
 
     // Clean up scheduler-owned timer FDs.
-    if (fd != interrupt_fd_ && timerfds_.count(fd) > 0) {
+    bool is_timer = fd != interrupt_fd_ && timerfds_.count(fd) > 0;
+    if (is_timer) {
 #if CO_TIMER_MODE == CO_TIMER_TIMERFD
       uint64_t val;
       (void)read(fd, &val, sizeof(val));
@@ -509,12 +510,18 @@ void Scheduler::ResumeCoroutine(Coroutine* coroutine, int value) {
         epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
       }
 #endif
-      if (fd_it != waiting_fds_.end() && fd_it->second.empty()) {
-        waiting_fds_.erase(fd_it);
-      }
-      coroutine_fds_.erase(it);
       timerfds_.erase(fd);
     }
+
+    if (fd_it != waiting_fds_.end() && fd_it->second.empty()) {
+      waiting_fds_.erase(fd_it);
+#if CO_POLL_MODE == CO_POLL_EPOLL
+      if (!is_timer && epoll_fd_ != -1) {
+        epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, fd, nullptr);
+      }
+#endif
+    }
+    coroutine_fds_.erase(it);
   }
 
   // Also detach from interrupt FD waiting list if present.

--- a/co/coroutine_cpp20.cc
+++ b/co/coroutine_cpp20.cc
@@ -183,10 +183,12 @@ void Scheduler::CleanupCoroutine(Coroutine* coroutine) {
       }
     }
   }
+
+  CleanupTimeoutFd(coroutine);
 }
 
 void Scheduler::WaitForFd(Coroutine* coroutine, int fd, uint32_t event_mask,
-                           uint64_t /*timeout_ns*/) {
+                           uint64_t timeout_ns) {
   if (!coroutine) return;
 
   // If already ready, schedule immediately.
@@ -282,6 +284,104 @@ void Scheduler::WaitForFd(Coroutine* coroutine, int fd, uint32_t event_mask,
         if (ret == -1 && errno == EEXIST) {
           epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, ifd, &ev);
         }
+      }
+    }
+#endif
+  }
+
+  // Set up timeout timer if requested.
+  if (timeout_ns > 0) {
+#if CO_TIMER_MODE == CO_TIMER_TIMERFD
+    int tfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    if (tfd != -1) {
+      struct itimerspec its = {};
+      its.it_value.tv_sec = timeout_ns / 1000000000ULL;
+      its.it_value.tv_nsec = timeout_ns % 1000000000ULL;
+      timerfd_settime(tfd, 0, &its, nullptr);
+
+      timerfds_.insert(tfd);
+      coroutine->SetTimeoutFd(tfd);
+
+      auto& timer_wait_list = waiting_fds_[tfd];
+      timer_wait_list.push_back(coroutine);
+
+#if CO_POLL_MODE == CO_POLL_EPOLL
+      if (epoll_fd_ != -1) {
+        struct epoll_event tev;
+        tev.data.fd = tfd;
+        tev.events = EPOLLIN;
+        int ret = epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, tfd, &tev);
+        if (ret == -1 && errno == EEXIST) {
+          epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, tfd, &tev);
+        }
+      }
+#endif
+    }
+
+#elif CO_TIMER_MODE == CO_TIMER_EVENT
+    int kq = kqueue();
+    if (kq != -1) {
+      timerfds_.insert(kq);
+      coroutine->SetTimeoutFd(kq);
+
+      struct kevent kev;
+      EV_SET(&kev, 1, EVFILT_TIMER, EV_ADD | EV_ONESHOT, NOTE_NSECONDS,
+             timeout_ns, 0);
+      kevent(kq, &kev, 1, nullptr, 0, nullptr);
+
+      auto& timer_wait_list = waiting_fds_[kq];
+      timer_wait_list.push_back(coroutine);
+    }
+
+#elif CO_TIMER_MODE == CO_TIMER_POSIX
+    int pipe_fds[2];
+    if (pipe(pipe_fds) == 0) {
+      int read_fd = pipe_fds[0];
+      int write_fd = pipe_fds[1];
+      fcntl(read_fd, F_SETFL, fcntl(read_fd, F_GETFL, 0) | O_NONBLOCK);
+      fcntl(write_fd, F_SETFL, fcntl(write_fd, F_GETFL, 0) | O_NONBLOCK);
+
+      struct sigevent se = {};
+      se.sigev_notify = SIGEV_THREAD;
+      se.sigev_notify_attributes = nullptr;
+      se.sigev_value.sival_int = write_fd;
+      se.sigev_notify_function = [](union sigval sv) {
+        char c = 1;
+        (void)write(sv.sival_int, &c, 1);
+      };
+
+      timer_t timer_id;
+      if (timer_create(CLOCK_REALTIME, &se, &timer_id) == 0) {
+        struct itimerspec its = {};
+        its.it_value.tv_sec = timeout_ns / 1000000000ULL;
+        its.it_value.tv_nsec = timeout_ns % 1000000000ULL;
+        if (timer_settime(timer_id, 0, &its, nullptr) == 0) {
+          timerfds_.insert(read_fd);
+          posix_timers_[read_fd] = {timer_id, write_fd};
+          coroutine->SetTimeoutFd(read_fd);
+
+          auto& timer_wait_list = waiting_fds_[read_fd];
+          timer_wait_list.push_back(coroutine);
+
+#if CO_POLL_MODE == CO_POLL_EPOLL
+          if (epoll_fd_ != -1) {
+            struct epoll_event tev;
+            tev.data.fd = read_fd;
+            tev.events = EPOLLIN;
+            int ret = epoll_ctl(epoll_fd_, EPOLL_CTL_ADD, read_fd, &tev);
+            if (ret == -1 && errno == EEXIST) {
+              epoll_ctl(epoll_fd_, EPOLL_CTL_MOD, read_fd, &tev);
+            }
+          }
+#endif
+        } else {
+          timer_delete(timer_id);
+          close(read_fd);
+          close(write_fd);
+        }
+      } else {
+        close(read_fd);
+        close(write_fd);
       }
     }
 #endif
@@ -436,10 +536,52 @@ void Scheduler::ResumeCoroutine(Coroutine* coroutine, int value) {
     }
   }
 
+  // Clean up timeout timer fd if present.
+  CleanupTimeoutFd(coroutine);
+
   coroutine->SetWaitResult(value);
   coroutine->SetState(Coroutine::State::kReady);
   ready_queue_.push_back(coroutine);
   TriggerInterrupt();
+}
+
+void Scheduler::CleanupTimeoutFd(Coroutine* coroutine) {
+  int tfd = coroutine->GetTimeoutFd();
+  if (tfd == -1) return;
+
+  auto tfd_it = waiting_fds_.find(tfd);
+  if (tfd_it != waiting_fds_.end()) {
+    auto& list = tfd_it->second;
+    list.erase(std::remove(list.begin(), list.end(), coroutine), list.end());
+    if (list.empty()) {
+      waiting_fds_.erase(tfd_it);
+#if CO_POLL_MODE == CO_POLL_EPOLL
+      if (epoll_fd_ != -1) {
+        epoll_ctl(epoll_fd_, EPOLL_CTL_DEL, tfd, nullptr);
+      }
+#endif
+    }
+  }
+
+  if (timerfds_.count(tfd) > 0) {
+#if CO_TIMER_MODE == CO_TIMER_TIMERFD
+    uint64_t val;
+    (void)read(tfd, &val, sizeof(val));
+#elif CO_TIMER_MODE == CO_TIMER_POSIX
+    auto pt = posix_timers_.find(tfd);
+    if (pt != posix_timers_.end()) {
+      struct itimerspec disarm = {};
+      timer_settime(pt->second.timer_id, 0, &disarm, nullptr);
+      timer_delete(pt->second.timer_id);
+      close(pt->second.write_fd);
+      posix_timers_.erase(pt);
+    }
+#endif
+    close(tfd);
+    timerfds_.erase(tfd);
+  }
+
+  coroutine->SetTimeoutFd(-1);
 }
 
 #if CO_POLL_MODE == CO_POLL_EPOLL

--- a/co/coroutine_cpp20.h
+++ b/co/coroutine_cpp20.h
@@ -160,6 +160,8 @@ private:
   void SetState(State state) { state_ = state; }
   void SetWaitResult(int result) { wait_result_ = result; }
   int GetWaitResult() const { return wait_result_; }
+  void SetTimeoutFd(int fd) { timeout_fd_ = fd; }
+  int GetTimeoutFd() const { return timeout_fd_; }
 
   inline void Resume(int value = 0);
 
@@ -171,6 +173,7 @@ private:
   int id_;
   int wait_result_ = -1;
   int interrupt_fd_ = -1;
+  int timeout_fd_ = -1;
   // Holds the callable (e.g. lambda) that produced the coroutine, keeping
   // its captures alive for the lifetime of the coroutine frame.
   std::shared_ptr<void> callable_storage_;
@@ -210,6 +213,7 @@ private:
   void ProcessReadyCoroutines();
   void ProcessEvents();
   void CleanupCoroutine(Coroutine* coroutine);
+  void CleanupTimeoutFd(Coroutine* coroutine);
   void TriggerInterrupt();
 #if CO_POLL_MODE == CO_POLL_EPOLL
   void DispatchEpollEvents(struct epoll_event* events, int count);

--- a/co/coroutine_cpp20.h
+++ b/co/coroutine_cpp20.h
@@ -187,7 +187,7 @@ public:
   ~Scheduler();
 
   void Run();
-  void Stop() { running_ = false; }
+  void Stop() { running_ = false; TriggerInterrupt(); }
 
   template<typename Func>
   Coroutine* Spawn(Func&& func, const std::string& name = "",

--- a/co/coroutine_cpp20.h
+++ b/co/coroutine_cpp20.h
@@ -100,6 +100,7 @@ struct BaseAwaitable;
 struct YieldAwaitable;
 struct WaitAwaitable;
 struct SleepAwaitable;
+template <typename T> struct ValueTask;
 
 // Represents a single C++20 stackless coroutine managed by a Scheduler.
 class Coroutine {
@@ -119,6 +120,7 @@ public:
   friend struct WaitAwaitable;
   friend struct SleepAwaitable;
   friend struct Task;
+  template <typename T> friend struct ValueTask;
 
   template<typename Func>
   Coroutine(Scheduler& scheduler, Func&& func, const std::string& name = "",
@@ -169,6 +171,9 @@ private:
   int id_;
   int wait_result_ = -1;
   int interrupt_fd_ = -1;
+  // Holds the callable (e.g. lambda) that produced the coroutine, keeping
+  // its captures alive for the lifetime of the coroutine frame.
+  std::shared_ptr<void> callable_storage_;
 };
 
 // Manages a set of coroutines, scheduling them cooperatively using
@@ -356,11 +361,18 @@ inline Coroutine::Coroutine(Scheduler& scheduler, Func&& func, const std::string
     interrupt_fd_(interrupt_fd == -1 ? -1 : dup(interrupt_fd)) {
   name_ = name.empty() ? "co-" + std::to_string(id_) : name;
 
+  // Store the callable so its captures (e.g. lambda captures) remain alive
+  // for the lifetime of the coroutine. C++20 coroutine frames hold a pointer
+  // to the callable's captures, so the callable must outlive the frame.
+  using FuncType = std::decay_t<Func>;
+  auto stored = std::make_shared<FuncType>(std::forward<Func>(func));
+  callable_storage_ = stored;
+
   auto task = [&]() {
-    if constexpr (std::is_invocable_v<Func, Coroutine&>) {
-      return func(*this);
+    if constexpr (std::is_invocable_v<FuncType, Coroutine&>) {
+      return (*stored)(*this);
     } else {
-      return func();
+      return (*stored)();
     }
   }();
   if constexpr (requires { task.handle_; }) {
@@ -394,6 +406,14 @@ inline SleepAwaitable Coroutine::Sleep(std::chrono::duration<Rep, Period> durati
   auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
   return Sleep(static_cast<uint64_t>(ns));
 }
+
+// Thread-local pointers to the currently running coroutine and its scheduler.
+// These are set automatically by the scheduler before each coroutine is resumed,
+// enabling the free functions below. Each thread running a scheduler gets its
+// own copy. Declared here (before Task/ValueTask) so that ValueTask::await_resume
+// can reference co20::self to restore the Coroutine's handle tracking.
+extern thread_local Coroutine* self;
+extern thread_local Scheduler* scheduler;
 
 // Task type returned by coroutine functions: [](Coroutine& co) -> Task { ... }
 struct Task {
@@ -437,12 +457,144 @@ struct Task {
   Task(Task&& other) noexcept : handle_(other.handle_) { other.handle_ = {}; }
 };
 
-// Thread-local pointers to the currently running coroutine and its scheduler.
-// These are set automatically by the scheduler before each coroutine is resumed,
-// enabling the free functions below. Each thread running a scheduler gets its
-// own copy.
-extern thread_local Coroutine* self;
-extern thread_local Scheduler* scheduler;
+// A sub-coroutine that produces a value of type T. Unlike Task (which is
+// managed by the Scheduler), ValueTask<T> is designed to be co_await'ed from
+// within a Task or another ValueTask. It uses symmetric transfer to run inline
+// with the caller, sharing the same Scheduler and Coroutine context.
+//
+// Usage:
+//   ValueTask<int> ComputeAsync(Coroutine& co) {
+//     co_await co.Wait(fd, POLLIN);
+//     co_return 42;
+//   }
+//
+//   // From within a Task:
+//   int result = co_await ComputeAsync(co);
+template <typename T>
+struct ValueTask {
+  struct promise_type {
+    T value_{};
+    std::coroutine_handle<> continuation_{};
+
+    std::suspend_always initial_suspend() noexcept { return {}; }
+
+    struct FinalAwaiter {
+      bool await_ready() const noexcept { return false; }
+      std::coroutine_handle<> await_suspend(
+          std::coroutine_handle<promise_type> h) const noexcept {
+        if (auto cont = h.promise().continuation_; cont)
+          return cont;
+        return std::noop_coroutine();
+      }
+      void await_resume() const noexcept {}
+    };
+
+    FinalAwaiter final_suspend() noexcept { return {}; }
+    void unhandled_exception() {}
+
+    ValueTask get_return_object() {
+      return ValueTask{std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+
+    template <typename U>
+    void return_value(U&& v) { value_ = std::forward<U>(v); }
+  };
+
+  std::coroutine_handle<promise_type> handle_;
+
+  explicit ValueTask(std::coroutine_handle<promise_type> h) : handle_(h) {}
+  ~ValueTask() { if (handle_) handle_.destroy(); }
+
+  ValueTask(const ValueTask&) = delete;
+  ValueTask& operator=(const ValueTask&) = delete;
+  ValueTask(ValueTask&& o) noexcept : handle_(o.handle_) { o.handle_ = {}; }
+  ValueTask& operator=(ValueTask&& o) noexcept {
+    if (this != &o) {
+      if (handle_) handle_.destroy();
+      handle_ = o.handle_;
+      o.handle_ = {};
+    }
+    return *this;
+  }
+
+  // Awaitable interface for co_await.
+  bool await_ready() const noexcept { return false; }
+
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<> caller) const noexcept {
+    handle_.promise().continuation_ = caller;
+    return handle_;
+  }
+
+  T await_resume() {
+    // Restore the Coroutine's handle to point to the caller (continuation)
+    // before this ValueTask is destroyed, preventing a dangling handle.
+    if (co20::self && handle_.promise().continuation_) {
+      co20::self->SetHandle(handle_.promise().continuation_);
+    }
+    return std::move(handle_.promise().value_);
+  }
+};
+
+// Void specialization of ValueTask for sub-coroutines that don't return a
+// value but still need to co_await internally.
+template <>
+struct ValueTask<void> {
+  struct promise_type {
+    std::coroutine_handle<> continuation_{};
+
+    std::suspend_always initial_suspend() noexcept { return {}; }
+
+    struct FinalAwaiter {
+      bool await_ready() const noexcept { return false; }
+      std::coroutine_handle<> await_suspend(
+          std::coroutine_handle<promise_type> h) const noexcept {
+        if (auto cont = h.promise().continuation_; cont)
+          return cont;
+        return std::noop_coroutine();
+      }
+      void await_resume() const noexcept {}
+    };
+
+    FinalAwaiter final_suspend() noexcept { return {}; }
+    void unhandled_exception() {}
+
+    ValueTask get_return_object() {
+      return ValueTask{std::coroutine_handle<promise_type>::from_promise(*this)};
+    }
+
+    void return_void() {}
+  };
+
+  std::coroutine_handle<promise_type> handle_;
+
+  explicit ValueTask(std::coroutine_handle<promise_type> h) : handle_(h) {}
+  ~ValueTask() { if (handle_) handle_.destroy(); }
+
+  ValueTask(const ValueTask&) = delete;
+  ValueTask& operator=(const ValueTask&) = delete;
+  ValueTask(ValueTask&& o) noexcept : handle_(o.handle_) { o.handle_ = {}; }
+  ValueTask& operator=(ValueTask&& o) noexcept {
+    if (this != &o) {
+      if (handle_) handle_.destroy();
+      handle_ = o.handle_;
+      o.handle_ = {};
+    }
+    return *this;
+  }
+
+  bool await_ready() const noexcept { return false; }
+
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<> caller) const noexcept {
+    handle_.promise().continuation_ = caller;
+    return handle_;
+  }
+
+  void await_resume() const {
+    if (co20::self && handle_.promise().continuation_) {
+      co20::self->SetHandle(handle_.promise().continuation_);
+    }
+  }
+};
 
 // --- Coroutine::Resume (needs thread_local declarations above) ---
 

--- a/co/test_cpp20.cc
+++ b/co/test_cpp20.cc
@@ -631,6 +631,198 @@ TEST(Cpp20, InterruptFdDataFirst) {
 #endif
 }
 
+// --- ValueTask<T> tests ---
+
+ValueTask<int> AddAsync(Coroutine& co, int a, int b) {
+  co_await co.Yield();
+  co_return a + b;
+}
+
+TEST(Cpp20ValueTask, BasicReturn) {
+  Scheduler scheduler;
+  int result = 0;
+
+  scheduler.Spawn([&result](Coroutine& co) -> Task {
+    result = co_await AddAsync(co, 3, 4);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ(7, result);
+}
+
+ValueTask<std::string> ReadFromPipeAsync(Coroutine& co, int read_fd) {
+  std::string data;
+  for (;;) {
+    int fd = co_await co.Wait(read_fd, POLLIN);
+    if (fd != read_fd) break;
+    char buf[64];
+    ssize_t n = read(read_fd, buf, sizeof(buf));
+    if (n <= 0) break;
+    data.append(buf, n);
+  }
+  co_return data;
+}
+
+TEST(Cpp20ValueTask, WithWait) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  std::string result;
+
+  scheduler.Spawn([&pipes, &result](Coroutine& co) -> Task {
+    result = co_await ReadFromPipeAsync(co, pipes[0]);
+    close(pipes[0]);
+    co_return;
+  }, "reader");
+
+  scheduler.Spawn([&pipes](Coroutine& co) -> Task {
+    co_await co.Yield();
+    const char* msg = "hello";
+    (void)write(pipes[1], msg, 5);
+    co_await co.Yield();
+    close(pipes[1]);
+    co_return;
+  }, "writer");
+
+  scheduler.Run();
+  EXPECT_EQ("hello", result);
+}
+
+ValueTask<int> InnerCompute(Coroutine& co, int x) {
+  co_await co.Yield();
+  co_return x * 2;
+}
+
+ValueTask<int> OuterCompute(Coroutine& co, int x) {
+  int doubled = co_await InnerCompute(co, x);
+  co_await co.Yield();
+  co_return doubled + 1;
+}
+
+TEST(Cpp20ValueTask, Nested) {
+  Scheduler scheduler;
+  int result = 0;
+
+  scheduler.Spawn([&result](Coroutine& co) -> Task {
+    result = co_await OuterCompute(co, 5);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ(11, result);
+}
+
+ValueTask<void> IncrementAsync(Coroutine& co, int& counter) {
+  co_await co.Yield();
+  counter++;
+  co_return;
+}
+
+TEST(Cpp20ValueTask, VoidReturn) {
+  Scheduler scheduler;
+  int counter = 0;
+
+  scheduler.Spawn([&counter](Coroutine& co) -> Task {
+    co_await IncrementAsync(co, counter);
+    co_await IncrementAsync(co, counter);
+    co_await IncrementAsync(co, counter);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ(3, counter);
+}
+
+ValueTask<void> WaitAndWrite(Coroutine& co, int write_fd) {
+  co_await co.Wait(write_fd, POLLOUT);
+  char c = 'V';
+  (void)write(write_fd, &c, 1);
+  co_return;
+}
+
+TEST(Cpp20ValueTask, VoidWithWait) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  char read_buf = 0;
+
+  scheduler.Spawn([&pipes, &read_buf](Coroutine& co) -> Task {
+    co_await WaitAndWrite(co, pipes[1]);
+    close(pipes[1]);
+    int fd = co_await co.Wait(pipes[0], POLLIN);
+    (void)fd;
+    (void)read(pipes[0], &read_buf, 1);
+    close(pipes[0]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ('V', read_buf);
+}
+
+ValueTask<int> AddWithFreeFunction(int a, int b) {
+  co_await co20::Yield();
+  co_return a + b;
+}
+
+TEST(Cpp20ValueTask, FreeFunctions) {
+  Scheduler scheduler;
+  int result = 0;
+
+  scheduler.Spawn([&result]() -> Task {
+    result = co_await AddWithFreeFunction(10, 20);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ(30, result);
+}
+
+TEST(Cpp20ValueTask, MultipleSequentialCalls) {
+  Scheduler scheduler;
+  int sum = 0;
+
+  scheduler.Spawn([&sum](Coroutine& co) -> Task {
+    for (int i = 1; i <= 5; i++) {
+      sum += co_await AddAsync(co, i, 0);
+    }
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_EQ(15, sum);
+}
+
+ValueTask<bool> CheckPipeReady(Coroutine& co, int read_fd, uint64_t timeout_ns) {
+  int fd = co_await co.Wait(read_fd, POLLIN, timeout_ns);
+  co_return fd == read_fd;
+}
+
+TEST(Cpp20ValueTask, BoolReturn) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool pipe_ready = false;
+
+  scheduler.Spawn([&pipes, &pipe_ready](Coroutine& co) -> Task {
+    // Write data first so the pipe is ready.
+    char c = 'x';
+    (void)write(pipes[1], &c, 1);
+    co_await co.Yield();
+    pipe_ready = co_await CheckPipeReady(co, pipes[0], 0);
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_TRUE(pipe_ready);
+}
+
 } // namespace co20
 
 #endif // CO20_HAVE_COROUTINES

--- a/co/test_cpp20.cc
+++ b/co/test_cpp20.cc
@@ -823,6 +823,119 @@ TEST(Cpp20ValueTask, BoolReturn) {
   EXPECT_TRUE(pipe_ready);
 }
 
+TEST(Cpp20WaitTimeout, DataArrivesBeforeTimeout) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool success = false;
+
+  scheduler.Spawn([&](Coroutine& co) -> Task {
+    char c = 'x';
+    (void)write(pipes[1], &c, 1);
+    co_await co.Yield();
+
+    int fd = co_await co.Wait(pipes[0], POLLIN, 1000000000ULL);
+    success = (fd == pipes[0]);
+
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_TRUE(success);
+}
+
+TEST(Cpp20WaitTimeout, TimeoutExpires) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool timed_out = false;
+
+  scheduler.Spawn([&](Coroutine& co) -> Task {
+    int fd = co_await co.Wait(pipes[0], POLLIN, 50000000ULL);
+    timed_out = (fd != pipes[0]);
+
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_TRUE(timed_out);
+}
+
+TEST(Cpp20WaitTimeout, FreeFunctionTimeout) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool timed_out = false;
+
+  scheduler.Spawn([&]() -> Task {
+    int fd = co_await co20::Wait(pipes[0], POLLIN, 50000000ULL);
+    timed_out = (fd != pipes[0]);
+
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_TRUE(timed_out);
+}
+
+TEST(Cpp20WaitTimeout, ValueTaskWithTimeout) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool result = true;
+
+  scheduler.Spawn([&](Coroutine& co) -> Task {
+    result = co_await CheckPipeReady(co, pipes[0], 50000000ULL);
+
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "test");
+
+  scheduler.Run();
+  EXPECT_FALSE(result);
+}
+
+TEST(Cpp20WaitTimeout, DataArrivesDuringWait) {
+  Scheduler scheduler;
+  int pipes[2];
+  ASSERT_EQ(0, pipe(pipes));
+
+  bool success = false;
+
+  scheduler.Spawn([&](Coroutine& co) -> Task {
+    // Spawn a helper that writes after a short delay.
+    co_await co.Yield();
+
+    int fd = co_await co.Wait(pipes[0], POLLIN, 500000000ULL);
+    success = (fd == pipes[0]);
+
+    close(pipes[0]);
+    close(pipes[1]);
+    co_return;
+  }, "waiter");
+
+  scheduler.Spawn([&](Coroutine& co) -> Task {
+    co_await co.Sleep(std::chrono::milliseconds(20));
+    char c = 'x';
+    (void)write(pipes[1], &c, 1);
+    co_return;
+  }, "writer");
+
+  scheduler.Run();
+  EXPECT_TRUE(success);
+}
+
 } // namespace co20
 
 #endif // CO20_HAVE_COROUTINES

--- a/co/test_cpp20.cc
+++ b/co/test_cpp20.cc
@@ -110,7 +110,7 @@ TEST(Cpp20, Loop) {
   
   // Create 10 coroutines, each yielding 10 times
   for (int i = 0; i < 10; i++) {
-    scheduler.Spawn([i](Coroutine& co) -> Task {
+    scheduler.Spawn([](Coroutine& co) -> Task {
       for (int j = 0; j < 10; j++) {
         co_await co.Yield();
       }
@@ -487,9 +487,11 @@ TEST(Cpp20, InterruptFd) {
     co_return;
   }, "waiting", efd);
 
-  scheduler.Spawn([&efd
-#if !defined(__linux__)
-    , &p
+  scheduler.Spawn([
+#if defined(__linux__)
+    &efd
+#else
+    &p
 #endif
     ](Coroutine& co) -> Task {
     co_await co.Sleep(50000000ULL); // 50ms
@@ -547,9 +549,11 @@ TEST(Cpp20, InterruptFdWithFreeFunction) {
     co_return;
   }, "waiting", efd);
 
-  scheduler.Spawn([&efd
-#if !defined(__linux__)
-    , &p
+  scheduler.Spawn([
+#if defined(__linux__)
+    &efd
+#else
+    &p
 #endif
     ](Coroutine& co) -> Task {
     co_await co.Sleep(50000000ULL);

--- a/http_client/BUILD.bazel
+++ b/http_client/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 cc_binary(
     name = "http_client",
     srcs = ["main.cc"],

--- a/http_server/BUILD.bazel
+++ b/http_server/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 cc_binary(
     name = "http_server",
     srcs = ["main.cc"],


### PR DESCRIPTION
Fixes a couple of C++20 issues. 

There was a snafu made.  This branch is currently released as 3.2.0 even though it wasn't merged into main.  Don't know how that happened, but this corrects it and is now version 3.2.1.