### PR TITLE
Add QNX support for context switcher and event fds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "coroutines",
-    version = "3.2.1",
+    version = "3.3.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -138,8 +138,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -203,7 +203,7 @@
   "moduleExtensions": {
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -260,7 +260,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/co/context.S
+++ b/co/context.S
@@ -11,7 +11,9 @@
 #define SYM_DATA(name) .p2align 2
 .section        __TEXT,__text,regular,pure_instructions
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__QNX__) || defined(__QNXNTO__)
+// QNX uses ELF and the same GNU-as syntax as Linux for symbol decoration,
+// so the same directives work for both.
 .text
 #define SYM(name) #name
 #define SYM_DATA(name) .type SYM(name), @function

--- a/co/coroutine.cc
+++ b/co/coroutine.cc
@@ -13,8 +13,6 @@
 #include <cassert>
 #include <fcntl.h>
 #include <iostream>
-#include <mutex>
-#include <unordered_map>
 
 #include "bitset.h"
 
@@ -80,32 +78,15 @@ namespace co {
 struct AbortException {};
 
 #if !defined(__APPLE__) && !defined(__linux__)
-// Portable fallback used on systems that have neither macOS kqueue nor Linux
-// eventfd (e.g. QNX).  We synthesize an "event fd" with a regular pipe: the
-// read end is the fd that callers see, and we keep the write end in a side
-// table so Trigger/Clear can use it.  This adds no dependencies beyond POSIX.
 namespace {
-std::mutex &EventFdMapMutex() {
-  static std::mutex m;
-  return m;
-}
-std::unordered_map<int, int> &EventFdMap() {
-  static std::unordered_map<int, int> m;
-  return m;
-}
-} // namespace
-#endif
 
-static int NewEventFd() {
-  int event_fd;
-#if defined(__APPLE__)
-  event_fd = kqueue();
-#elif defined(__linux__)
-  event_fd = eventfd(0, EFD_NONBLOCK);
-#else
+// Allocate a non-blocking pipe pair, returning {read_fd, write_fd} or
+// {-1, -1} on failure.  Used as the portable fallback for EventFd on systems
+// that have neither Linux eventfd nor macOS kqueue.
+std::pair<int, int> MakeNonBlockingPipe() {
   int pipefd[2];
   if (::pipe(pipefd) == -1) {
-    return -1;
+    return {-1, -1};
   }
   for (int i = 0; i < 2; ++i) {
     int flags = fcntl(pipefd[i], F_GETFL, 0);
@@ -113,74 +94,115 @@ static int NewEventFd() {
       (void)fcntl(pipefd[i], F_SETFL, flags | O_NONBLOCK);
     }
   }
-  {
-    std::lock_guard<std::mutex> lock(EventFdMapMutex());
-    EventFdMap()[pipefd[0]] = pipefd[1];
-  }
-  event_fd = pipefd[0];
-#endif
-  return event_fd;
+  return {pipefd[0], pipefd[1]};
 }
 
-static void CloseEventFd(int fd) {
+} // namespace
+#endif
+
+EventFd EventFd::Create() {
+  EventFd e;
+#if defined(__APPLE__)
+  int fd = kqueue();
   if (fd == -1) {
+    return e;
+  }
+  e.poll_fd = fd;
+  e.trigger_fd = fd;
+#elif defined(__linux__)
+  int fd = eventfd(0, EFD_NONBLOCK);
+  if (fd == -1) {
+    return e;
+  }
+  e.poll_fd = fd;
+  e.trigger_fd = fd;
+#else
+  auto pipefd = MakeNonBlockingPipe();
+  if (pipefd.first == -1) {
+    return e;
+  }
+  e.poll_fd = pipefd.first;
+  e.trigger_fd = pipefd.second;
+#endif
+  return e;
+}
+
+EventFd EventFd::CreateAbort() {
+  EventFd e;
+#if defined(__APPLE__)
+  int kq = kqueue();
+  if (kq == -1) {
+    return e;
+  }
+  // Pre-register the EVFILT_USER filter so that Trigger() can fire it.
+  struct kevent ev;
+  EV_SET(&ev, 1, EVFILT_USER, EV_ADD, NOTE_ABSOLUTE, 0, 0);
+  kevent(kq, &ev, 1, NULL, 0, NULL);
+  e.poll_fd = kq;
+  e.trigger_fd = kq;
+#elif defined(__linux__)
+  int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  if (fd == -1) {
+    return e;
+  }
+  e.poll_fd = fd;
+  e.trigger_fd = fd;
+#else
+  auto pipefd = MakeNonBlockingPipe();
+  if (pipefd.first == -1) {
+    return e;
+  }
+  e.poll_fd = pipefd.first;
+  e.trigger_fd = pipefd.second;
+#endif
+  return e;
+}
+
+void EventFd::Trigger() const {
+  if (trigger_fd == -1) {
     return;
   }
-#if !defined(__APPLE__) && !defined(__linux__)
-  int write_fd = -1;
-  {
-    std::lock_guard<std::mutex> lock(EventFdMapMutex());
-    auto it = EventFdMap().find(fd);
-    if (it != EventFdMap().end()) {
-      write_fd = it->second;
-      EventFdMap().erase(it);
-    }
-  }
-  if (write_fd != -1) {
-    close(write_fd);
-  }
-#endif
-  close(fd);
-}
-
-static void TriggerEvent(int fd) {
 #if defined(__APPLE__)
   struct kevent e;
   EV_SET(&e, 1, EVFILT_USER, EV_ADD, NOTE_TRIGGER, 0, nullptr);
-  kevent(fd, &e, 1, 0, 0, 0); // Trigger USER event
+  kevent(trigger_fd, &e, 1, 0, 0, 0);
 #elif defined(__linux__)
   int64_t val = 1;
-  (void)write(fd, &val, 8);
+  (void)write(trigger_fd, &val, 8);
 #else
-  int write_fd = -1;
-  {
-    std::lock_guard<std::mutex> lock(EventFdMapMutex());
-    auto it = EventFdMap().find(fd);
-    if (it != EventFdMap().end()) {
-      write_fd = it->second;
-    }
+  char ch = 'x';
+  (void)write(trigger_fd, &ch, 1);
+#endif
+}
+
+void EventFd::Clear() const {
+  if (poll_fd == -1) {
+    return;
   }
-  if (write_fd != -1) {
-    char ch = 'x';
-    (void)write(write_fd, &ch, 1);
+#if defined(__APPLE__)
+  struct kevent e;
+  EV_SET(&e, 1, EVFILT_USER, EV_DELETE, NOTE_TRIGGER, 0, nullptr);
+  kevent(poll_fd, &e, 1, nullptr, 0, 0);
+#elif defined(__linux__)
+  int64_t val;
+  (void)read(poll_fd, &val, 8);
+#else
+  // Drain the read end of the pipe.
+  char buf[64];
+  while (::read(poll_fd, buf, sizeof(buf)) > 0) {
   }
 #endif
 }
 
-static void ClearEvent(int fd) {
-#if defined(__APPLE__)
-  struct kevent e;
-  EV_SET(&e, 1, EVFILT_USER, EV_DELETE, NOTE_TRIGGER, 0, nullptr);
-  kevent(fd, &e, 1, nullptr, 0, 0); // Clear USER event
-#elif defined(__linux__)
-  int64_t val;
-  (void)read(fd, &val, 8);
-#else
-  // Drain the read end of the pipe.
-  char buf[64];
-  while (::read(fd, buf, sizeof(buf)) > 0) {
+void EventFd::Close() {
+  if (trigger_fd != -1 && trigger_fd != poll_fd) {
+    ::close(trigger_fd);
   }
-#endif
+  if (poll_fd != -1) {
+    ::close(poll_fd);
+  }
+  poll_fd = -1;
+  trigger_fd = -1;
 }
 
 #if CO_CTX_MODE == CO_CTX_SETJMP
@@ -278,20 +300,13 @@ Coroutine::Coroutine(CoroutineScheduler &scheduler,
       stack_.data(), static_cast<char *>(stack_.data()) + stack_.size());
 #endif
 
+  event_fd_ = EventFd::Create();
+  if (!event_fd_.IsValid()) {
+    fprintf(stderr, "Failed to allocate event fd: %s\n", strerror(errno));
+    abort();
+  }
 #if CO_POLL_MODE == CO_POLL_EPOLL
-  int efd = NewEventFd();
-  if (efd == -1) {
-    fprintf(stderr, "Failed to allocate event fd: %s\n", strerror(errno));
-    abort();
-  }
-  yield_fd_ = YieldedCoroutine(this, efd, EPOLLIN);
-#else
-  event_fd_.fd = NewEventFd();
-  if (event_fd_.fd == -1) {
-    fprintf(stderr, "Failed to allocate event fd: %s\n", strerror(errno));
-    abort();
-  }
-  event_fd_.events = POLLIN;
+  yield_fd_ = YieldedCoroutine(this, event_fd_.poll_fd, EPOLLIN);
 #endif
 
   // Might as well take the hit for allocating the pollfd vector when the
@@ -307,14 +322,8 @@ Coroutine::Coroutine(CoroutineScheduler &scheduler,
 }
 
 Coroutine::~Coroutine() {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  CloseEventFd(yield_fd_.fd);
-#else
-  CloseEventFd(event_fd_.fd);
-#endif
-  if (abort_fd_ != -1) {
-    CloseEventFd(abort_fd_);
-  }
+  event_fd_.Close();
+  abort_fd_.Close();
 #if CO_TIMER_MODE == CO_TIMER_POSIX
   CleanupPosixTimer();
 #endif
@@ -519,21 +528,6 @@ int MakeTimer([[maybe_unused]] const Coroutine *coroutine, uint64_t ns) {
 #endif
 }
 
-static int MakeAbortEvent() {
-#if defined(__APPLE__)
-  // On MacOS we use a kqueue.
-  int kq = kqueue();
-  struct kevent e;
-
-  EV_SET(&e, 1, EVFILT_USER, EV_ADD, NOTE_ABSOLUTE, 0, 0);
-  kevent(kq, &e, 1, NULL, 0, NULL);
-  return kq;
-#elif defined(__linux__)
-  // On Linux we use an eventfd.
-  return eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-#endif
-}
-
 int Coroutine::EndOfWait(int timer_fd) const {
   wait_fds_.clear();
   if (timer_fd != -1) {
@@ -547,7 +541,7 @@ int Coroutine::EndOfWait(int timer_fd) const {
     close(timer_fd);
 #endif
   }
-  if (wait_result_ == abort_fd_) {
+  if (abort_fd_.IsValid() && wait_result_ == abort_fd_.poll_fd) {
     abort_pending_ = true;
     throw AbortException();
   }
@@ -576,13 +570,13 @@ void Coroutine::AddAbortFd() const {
   if (!scheduler_.aborts_enabled_) {
     return;
   }
-  if (abort_fd_ == -1) {
-    abort_fd_ = MakeAbortEvent();
+  if (!abort_fd_.IsValid()) {
+    abort_fd_ = EventFd::CreateAbort();
   }
 #if CO_POLL_MODE == CO_POLL_EPOLL
-  wait_fds_.push_back(YieldedCoroutine(this, abort_fd_, EPOLLIN));
+  wait_fds_.push_back(YieldedCoroutine(this, abort_fd_.poll_fd, EPOLLIN));
 #else
-  struct pollfd abortfd = {.fd = abort_fd_, .events = POLLIN};
+  struct pollfd abortfd = {.fd = abort_fd_.poll_fd, .events = POLLIN};
   wait_fds_.push_back(abortfd);
 #endif
 }
@@ -839,21 +833,9 @@ void Coroutine::CleanupPosixTimer() const {
 
 #endif
 
-void Coroutine::TriggerEvent() const {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  co::TriggerEvent(yield_fd_.fd);
-#else
-  co::TriggerEvent(event_fd_.fd);
-#endif
-}
+void Coroutine::TriggerEvent() const { event_fd_.Trigger(); }
 
-void Coroutine::ClearEvent() const {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  co::ClearEvent(yield_fd_.fd);
-#else
-  co::ClearEvent(event_fd_.fd);
-#endif
-}
+void Coroutine::ClearEvent() const { event_fd_.Clear(); }
 
 #if CO_POLL_MODE == CO_POLL_POLL
 void Coroutine::AddPollFds(std::vector<struct pollfd> &pollfds,
@@ -862,7 +844,8 @@ void Coroutine::AddPollFds(std::vector<struct pollfd> &pollfds,
   case State::kCoReady:
     [[fallthrough]];
   case State::kCoYielded:
-    pollfds.push_back(event_fd_);
+    pollfds.push_back(
+        {.fd = event_fd_.poll_fd, .events = POLLIN, .revents = 0});
     covec.push_back(this);
     break;
   case State::kCoWaiting:
@@ -1096,22 +1079,13 @@ void Coroutine::Resume(int value) const {
 
 void Coroutine::Abort() const {
   abort_pending_ = true;
-  if (abort_fd_ == -1) {
-    return;
-  }
-  co::TriggerEvent(abort_fd_);
+  abort_fd_.Trigger();
 }
 
 void Coroutine::GetAllFds(std::vector<int> &fds) const {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  if (yield_fd_.fd != -1) {
-    fds.push_back(yield_fd_.fd);
+  if (event_fd_.poll_fd != -1) {
+    fds.push_back(event_fd_.poll_fd);
   }
-#else
-  if (event_fd_.fd != -1) {
-    fds.push_back(event_fd_.fd);
-  }
-#endif
   if (state_ == State::kCoWaiting) {
     for (auto &fd : wait_fds_) {
       fds.push_back(fd.fd);
@@ -1120,31 +1094,27 @@ void Coroutine::GetAllFds(std::vector<int> &fds) const {
 }
 
 CoroutineScheduler::CoroutineScheduler() {
+  interrupt_fd_ = EventFd::Create();
+  co_interrupt_fd_ = EventFd::Create();
 #if CO_POLL_MODE == CO_POLL_EPOLL
-  interrupt_fd_ = NewEventFd();
-  co_interrupt_fd_ = NewEventFd();
   epoll_fd_ = epoll_create1(0);
   if (epoll_fd_ == -1) {
     std::cerr << "Failed to create epoll fd: " << strerror(errno) << std::endl;
     abort();
   }
-  AddEpollFd(interrupt_fd_, EPOLLIN);
-  AddEpollFd(co_interrupt_fd_, EPOLLIN);
-#else
-  interrupt_fd_.fd = NewEventFd();
-  interrupt_fd_.events = POLLIN;
-  co_interrupt_fd_.fd = NewEventFd();
-  co_interrupt_fd_.events = POLLIN;
+  AddEpollFd(interrupt_fd_.poll_fd, EPOLLIN);
+  AddEpollFd(co_interrupt_fd_.poll_fd, EPOLLIN);
 #endif
 }
 
 CoroutineScheduler::~CoroutineScheduler() {
 #if CO_POLL_MODE == CO_POLL_EPOLL
-  close(epoll_fd_);
-  close(interrupt_fd_);
-#else
-  CloseEventFd(interrupt_fd_.fd);
+  if (epoll_fd_ != -1) {
+    close(epoll_fd_);
+  }
 #endif
+  interrupt_fd_.Close();
+  co_interrupt_fd_.Close();
 }
 
 
@@ -1237,8 +1207,10 @@ void CoroutineScheduler::BuildPollFds(PollState *poll_state) {
   poll_state->pollfds.clear();
   poll_state->coroutines.clear();
 
-  poll_state->pollfds.push_back(interrupt_fd_);
-  poll_state->pollfds.push_back(co_interrupt_fd_);
+  poll_state->pollfds.push_back(
+      {.fd = interrupt_fd_.poll_fd, .events = POLLIN, .revents = 0});
+  poll_state->pollfds.push_back(
+      {.fd = co_interrupt_fd_.poll_fd, .events = POLLIN, .revents = 0});
   for (auto *c : coroutines_) {
     auto state = c->GetState();
     if (state == Coroutine::State::kCoNew ||
@@ -1303,10 +1275,10 @@ void CoroutineScheduler::Run() {
       }
       auto it = waiting_coroutines_.find(event.data.fd);
       if (it == waiting_coroutines_.end()) {
-        if (event.data.fd == interrupt_fd_) {
-          events.push_back(YieldedCoroutine(nullptr, interrupt_fd_));
-        } else if (event.data.fd == co_interrupt_fd_) {
-          events.push_back(YieldedCoroutine(nullptr, co_interrupt_fd_));
+        if (event.data.fd == interrupt_fd_.poll_fd) {
+          events.push_back(YieldedCoroutine(nullptr, interrupt_fd_.poll_fd));
+        } else if (event.data.fd == co_interrupt_fd_.poll_fd) {
+          events.push_back(YieldedCoroutine(nullptr, co_interrupt_fd_.poll_fd));
         }
         continue;
       }
@@ -1317,11 +1289,13 @@ void CoroutineScheduler::Run() {
     // Sort the events by the time they have been waiting.
     std::sort(events.begin(), events.end(),
               [this](const YieldedCoroutine &a, const YieldedCoroutine &b) {
-                if (a.fd == interrupt_fd_ || b.fd == interrupt_fd_) {
+                if (a.fd == interrupt_fd_.poll_fd ||
+                    b.fd == interrupt_fd_.poll_fd) {
                   // Interrupt fd always goes first.
                   return true;
                 }
-                if (a.fd == co_interrupt_fd_ || b.fd == co_interrupt_fd_) {
+                if (a.fd == co_interrupt_fd_.poll_fd ||
+                    b.fd == co_interrupt_fd_.poll_fd) {
                   // Co interrupt fd always goes last.
                   return false;
                 }
@@ -1363,12 +1337,13 @@ void CoroutineScheduler::Run() {
     // Sort the events by the time they have been waiting.
     std::sort(events.begin(), events.end(),
               [this](const YieldedCoroutine &a, const YieldedCoroutine &b) {
-                if (a.fd == interrupt_fd_.fd || b.fd == interrupt_fd_.fd) {
+                if (a.fd == interrupt_fd_.poll_fd ||
+                    b.fd == interrupt_fd_.poll_fd) {
                   // Interrupt fd always goes first.
                   return true;
                 }
-                if (a.fd == co_interrupt_fd_.fd ||
-                    b.fd == co_interrupt_fd_.fd) {
+                if (a.fd == co_interrupt_fd_.poll_fd ||
+                    b.fd == co_interrupt_fd_.poll_fd) {
                   // Co interrupt fd always goes last.
                   return false;
                 }
@@ -1405,24 +1380,14 @@ void CoroutineScheduler::Run() {
       }
       YieldedCoroutine *c = &events[index];
       index++;
-#if CO_POLL_MODE == CO_POLL_EPOLL
-      if (c->fd == interrupt_fd_) {
-        ClearEvent(interrupt_fd_);
+      if (c->fd == interrupt_fd_.poll_fd) {
+        interrupt_fd_.Clear();
         continue;
       }
-      if (c->fd == co_interrupt_fd_) {
+      if (c->fd == co_interrupt_fd_.poll_fd) {
         // Coroutine interrupt triggered, don't clear it.
         continue;
       }
-#else
-      if (c->fd == interrupt_fd_.fd) {
-        ClearEvent(interrupt_fd_.fd);
-        continue;
-      }
-      if (c->fd == co_interrupt_fd_.fd) {
-        continue;
-      }
-#endif
 
       if (c->co == nullptr) {
         // Shouldn't happen.
@@ -1540,11 +1505,7 @@ uint32_t CoroutineScheduler::AllocateId() {
 }
 
 void CoroutineScheduler::TriggerInterrupt() const {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  TriggerEvent(co_interrupt_fd_);
-#else
-  TriggerEvent(co_interrupt_fd_.fd);
-#endif
+  co_interrupt_fd_.Trigger();
 }
 
 void CoroutineScheduler::Stop() {
@@ -1556,11 +1517,7 @@ void CoroutineScheduler::Stop() {
   } else {
     running_ = false;
   }
-#if CO_POLL_MODE == CO_POLL_EPOLL
-  TriggerEvent(interrupt_fd_);
-#else
-  TriggerEvent(interrupt_fd_.fd);
-#endif
+  interrupt_fd_.Trigger();
 }
 
 void CoroutineScheduler::Show() {
@@ -1581,12 +1538,9 @@ std::vector<int> CoroutineScheduler::GetAllFds() const {
   std::vector<int> fds;
 #if CO_POLL_MODE == CO_POLL_EPOLL
   fds.push_back(epoll_fd_);
-  fds.push_back(interrupt_fd_);
-  fds.push_back(co_interrupt_fd_);
-#else
-  fds.push_back(interrupt_fd_.fd);
-  fds.push_back(co_interrupt_fd_.fd);
 #endif
+  fds.push_back(interrupt_fd_.poll_fd);
+  fds.push_back(co_interrupt_fd_.poll_fd);
   for (auto *co : coroutines_) {
     co->GetAllFds(fds);
   }

--- a/co/coroutine.cc
+++ b/co/coroutine.cc
@@ -17,14 +17,20 @@
 #include "bitset.h"
 
 #if defined(__APPLE__)
-#include <sys/event.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#endif
 
-#elif defined(__linux__)
+#if CO_EVENT_MODE == CO_EVENT_KQUEUE || CO_TIMER_MODE == CO_TIMER_EVENT
+#include <sys/event.h>
+#endif
+
+#if CO_EVENT_MODE == CO_EVENT_EVENTFD
 #include <sys/eventfd.h>
-#include <sys/timerfd.h>
+#endif
 
+#if CO_TIMER_MODE == CO_TIMER_TIMERFD
+#include <sys/timerfd.h>
 #endif
 
 #if CO_TIMER_MODE == CO_TIMER_POSIX
@@ -77,12 +83,11 @@ namespace co {
 
 struct AbortException {};
 
-#if !defined(__APPLE__) && !defined(__linux__)
+#if CO_EVENT_MODE == CO_EVENT_PIPE
 namespace {
 
 // Allocate a non-blocking pipe pair, returning {read_fd, write_fd} or
-// {-1, -1} on failure.  Used as the portable fallback for EventFd on systems
-// that have neither Linux eventfd nor macOS kqueue.
+// {-1, -1} on failure.  Used as the portable fallback for EventFd.
 std::pair<int, int> MakeNonBlockingPipe() {
   int pipefd[2];
   if (::pipe(pipefd) == -1) {
@@ -102,34 +107,36 @@ std::pair<int, int> MakeNonBlockingPipe() {
 
 EventFd EventFd::Create() {
   EventFd e;
-#if defined(__APPLE__)
+#if CO_EVENT_MODE == CO_EVENT_KQUEUE
   int fd = kqueue();
   if (fd == -1) {
     return e;
   }
   e.poll_fd = fd;
   e.trigger_fd = fd;
-#elif defined(__linux__)
+#elif CO_EVENT_MODE == CO_EVENT_EVENTFD
   int fd = eventfd(0, EFD_NONBLOCK);
   if (fd == -1) {
     return e;
   }
   e.poll_fd = fd;
   e.trigger_fd = fd;
-#else
+#elif CO_EVENT_MODE == CO_EVENT_PIPE
   auto pipefd = MakeNonBlockingPipe();
   if (pipefd.first == -1) {
     return e;
   }
   e.poll_fd = pipefd.first;
   e.trigger_fd = pipefd.second;
+#else
+#error "Unknown CO_EVENT_MODE"
 #endif
   return e;
 }
 
 EventFd EventFd::CreateAbort() {
   EventFd e;
-#if defined(__APPLE__)
+#if CO_EVENT_MODE == CO_EVENT_KQUEUE
   int kq = kqueue();
   if (kq == -1) {
     return e;
@@ -140,20 +147,22 @@ EventFd EventFd::CreateAbort() {
   kevent(kq, &ev, 1, NULL, 0, NULL);
   e.poll_fd = kq;
   e.trigger_fd = kq;
-#elif defined(__linux__)
+#elif CO_EVENT_MODE == CO_EVENT_EVENTFD
   int fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
   if (fd == -1) {
     return e;
   }
   e.poll_fd = fd;
   e.trigger_fd = fd;
-#else
+#elif CO_EVENT_MODE == CO_EVENT_PIPE
   auto pipefd = MakeNonBlockingPipe();
   if (pipefd.first == -1) {
     return e;
   }
   e.poll_fd = pipefd.first;
   e.trigger_fd = pipefd.second;
+#else
+#error "Unknown CO_EVENT_MODE"
 #endif
   return e;
 }
@@ -162,16 +171,18 @@ void EventFd::Trigger() const {
   if (trigger_fd == -1) {
     return;
   }
-#if defined(__APPLE__)
+#if CO_EVENT_MODE == CO_EVENT_KQUEUE
   struct kevent e;
   EV_SET(&e, 1, EVFILT_USER, EV_ADD, NOTE_TRIGGER, 0, nullptr);
   kevent(trigger_fd, &e, 1, 0, 0, 0);
-#elif defined(__linux__)
+#elif CO_EVENT_MODE == CO_EVENT_EVENTFD
   int64_t val = 1;
   (void)write(trigger_fd, &val, 8);
-#else
+#elif CO_EVENT_MODE == CO_EVENT_PIPE
   char ch = 'x';
   (void)write(trigger_fd, &ch, 1);
+#else
+#error "Unknown CO_EVENT_MODE"
 #endif
 }
 
@@ -179,18 +190,20 @@ void EventFd::Clear() const {
   if (poll_fd == -1) {
     return;
   }
-#if defined(__APPLE__)
+#if CO_EVENT_MODE == CO_EVENT_KQUEUE
   struct kevent e;
   EV_SET(&e, 1, EVFILT_USER, EV_DELETE, NOTE_TRIGGER, 0, nullptr);
   kevent(poll_fd, &e, 1, nullptr, 0, 0);
-#elif defined(__linux__)
+#elif CO_EVENT_MODE == CO_EVENT_EVENTFD
   int64_t val;
   (void)read(poll_fd, &val, 8);
-#else
+#elif CO_EVENT_MODE == CO_EVENT_PIPE
   // Drain the read end of the pipe.
   char buf[64];
   while (::read(poll_fd, buf, sizeof(buf)) > 0) {
   }
+#else
+#error "Unknown CO_EVENT_MODE"
 #endif
 }
 

--- a/co/coroutine.cc
+++ b/co/coroutine.cc
@@ -13,6 +13,8 @@
 #include <cassert>
 #include <fcntl.h>
 #include <iostream>
+#include <mutex>
+#include <unordered_map>
 
 #include "bitset.h"
 
@@ -77,6 +79,23 @@ namespace co {
 
 struct AbortException {};
 
+#if !defined(__APPLE__) && !defined(__linux__)
+// Portable fallback used on systems that have neither macOS kqueue nor Linux
+// eventfd (e.g. QNX).  We synthesize an "event fd" with a regular pipe: the
+// read end is the fd that callers see, and we keep the write end in a side
+// table so Trigger/Clear can use it.  This adds no dependencies beyond POSIX.
+namespace {
+std::mutex &EventFdMapMutex() {
+  static std::mutex m;
+  return m;
+}
+std::unordered_map<int, int> &EventFdMap() {
+  static std::unordered_map<int, int> m;
+  return m;
+}
+} // namespace
+#endif
+
 static int NewEventFd() {
   int event_fd;
 #if defined(__APPLE__)
@@ -84,7 +103,21 @@ static int NewEventFd() {
 #elif defined(__linux__)
   event_fd = eventfd(0, EFD_NONBLOCK);
 #else
-#error "Unknown operating system"
+  int pipefd[2];
+  if (::pipe(pipefd) == -1) {
+    return -1;
+  }
+  for (int i = 0; i < 2; ++i) {
+    int flags = fcntl(pipefd[i], F_GETFL, 0);
+    if (flags != -1) {
+      (void)fcntl(pipefd[i], F_SETFL, flags | O_NONBLOCK);
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(EventFdMapMutex());
+    EventFdMap()[pipefd[0]] = pipefd[1];
+  }
+  event_fd = pipefd[0];
 #endif
   return event_fd;
 }
@@ -93,6 +126,20 @@ static void CloseEventFd(int fd) {
   if (fd == -1) {
     return;
   }
+#if !defined(__APPLE__) && !defined(__linux__)
+  int write_fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(EventFdMapMutex());
+    auto it = EventFdMap().find(fd);
+    if (it != EventFdMap().end()) {
+      write_fd = it->second;
+      EventFdMap().erase(it);
+    }
+  }
+  if (write_fd != -1) {
+    close(write_fd);
+  }
+#endif
   close(fd);
 }
 
@@ -105,7 +152,18 @@ static void TriggerEvent(int fd) {
   int64_t val = 1;
   (void)write(fd, &val, 8);
 #else
-#error "Unknown operating system"
+  int write_fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(EventFdMapMutex());
+    auto it = EventFdMap().find(fd);
+    if (it != EventFdMap().end()) {
+      write_fd = it->second;
+    }
+  }
+  if (write_fd != -1) {
+    char ch = 'x';
+    (void)write(write_fd, &ch, 1);
+  }
 #endif
 }
 
@@ -118,7 +176,10 @@ static void ClearEvent(int fd) {
   int64_t val;
   (void)read(fd, &val, 8);
 #else
-#error "Unknown operating system"
+  // Drain the read end of the pipe.
+  char buf[64];
+  while (::read(fd, buf, sizeof(buf)) > 0) {
+  }
 #endif
 }
 

--- a/co/coroutine.h
+++ b/co/coroutine.h
@@ -236,6 +236,51 @@ struct YieldedCoroutine {
   uint32_t events = 0;
 };
 
+// EventFd is a portable representation of a triggerable file descriptor used
+// to wake up coroutines.  On Linux it wraps an eventfd; on macOS it wraps a
+// kqueue (with an EVFILT_USER filter); on other systems it is implemented as
+// a non-blocking pipe pair.  In all cases:
+//
+//   - poll_fd    is the file descriptor that should be added to a poll/epoll
+//                set.  It becomes readable when the event is triggered.
+//   - trigger_fd is the file descriptor that should be written to in order to
+//                signal the event.  On Linux/macOS it is the same fd as
+//                poll_fd; on systems backed by a pipe it is the write end of
+//                the pipe.
+//
+// This is functionally equivalent to toolbelt::TriggerFd but is self-contained
+// to avoid a circular dependency on cpp_toolbelt.
+struct EventFd {
+  int poll_fd = -1;
+  int trigger_fd = -1;
+
+  bool IsValid() const { return poll_fd != -1; }
+
+  // Trigger the event so that anything polling poll_fd will wake up.
+  void Trigger() const;
+
+  // Drain a previously triggered event (no-op if not triggered).
+  void Clear() const;
+
+  // Close any owned file descriptors and reset to the invalid state.
+  void Close();
+
+  // Reset to the invalid state without closing any file descriptors.
+  void Reset() {
+    poll_fd = -1;
+    trigger_fd = -1;
+  }
+
+  // Allocate a new event fd suitable for general signalling.  Returns an
+  // invalid EventFd (IsValid() == false) on failure.
+  static EventFd Create();
+
+  // Allocate a new event fd suitable for use as an abort signal.  On Linux
+  // this is an eventfd with EFD_CLOEXEC set; on other platforms it behaves
+  // identically to Create().
+  static EventFd CreateAbort();
+};
+
 struct CoroutineOptions {
   std::string name;
   int interrupt_fd = -1;
@@ -546,16 +591,20 @@ protected:
   // Aborting a coroutine causes it to correctly terminate its execution function, unwinding
   // the stack and calling destructors.  It is a clean way to terminate a coroutine without
   // having to use an interrupt fd and check for termination in the coroutine function.
-  mutable int abort_fd_ = -1;
+  mutable EventFd abort_fd_;
   mutable bool abort_pending_ = false;    // Coroutine::Abort called.
   mutable bool aborted_ = false;      // Abort has been processed.
+
+  // Event fd used to wake this coroutine up.  The scheduler waits on
+  // event_fd_.poll_fd; TriggerEvent()/ClearEvent() write/read via the
+  // EventFd's trigger_fd/poll_fd as appropriate.
+  mutable EventFd event_fd_;
 
 #if CO_POLL_MODE == CO_POLL_EPOLL
   mutable YieldedCoroutine yield_fd_;
   mutable std::vector<YieldedCoroutine> wait_fds_;
   mutable int num_epoll_events_ = 0;
 #else
-  mutable struct pollfd event_fd_; // Pollfd for event.
   mutable std::vector<struct pollfd>
       wait_fds_; // Pollfds for waiting for an fd.
 #endif
@@ -639,13 +688,7 @@ public:
   void RemoveCoroutine(const Coroutine *c);
   void StartCoroutine(Coroutine *c);
 
-  int GetInterruptFd() const {
-#if CO_POLL_MODE == CO_POLL_EPOLL
-    return co_interrupt_fd_;
-#else
-    return co_interrupt_fd_.fd;
-#endif
-  }
+  int GetInterruptFd() const { return co_interrupt_fd_.poll_fd; }
 
   void TriggerInterrupt() const;
 
@@ -726,14 +769,12 @@ protected:
   absl::flat_hash_map<int, absl::flat_hash_set<YieldedCoroutine *>>
       waiting_coroutines_;
   int epoll_fd_ = -1;
-  int interrupt_fd_ = -1;
-  int co_interrupt_fd_ = -1;
   size_t num_epoll_events_ = 0;
 #else
   PollState poll_state_;
-  struct pollfd interrupt_fd_ = {-1, POLLIN, 0};
-  struct pollfd co_interrupt_fd_ = {-1, POLLIN, 0};
 #endif
+  EventFd interrupt_fd_;
+  EventFd co_interrupt_fd_;
 
   uint64_t tick_count_ = 0;
   CompletionCallback completion_callback_;

--- a/co/coroutine.h
+++ b/co/coroutine.h
@@ -53,6 +53,18 @@
 #define CO_TIMER_EVENT 2
 #define CO_TIMER_POSIX 3
 
+// Event-fd backend selection (used by co::EventFd):
+// 1. CO_EVENT_EVENTFD - Linux eventfd (Linux only)
+// 2. CO_EVENT_KQUEUE  - macOS kqueue with EVFILT_USER (macOS only)
+// 3. CO_EVENT_PIPE    - non-blocking pipe pair (portable)
+//
+// You can override the default backend by defining CO_EVENT_MODE before
+// including this header (e.g. -DCO_EVENT_MODE=CO_EVENT_PIPE) so you can
+// exercise the portable pipe-based path on Linux/macOS.
+#define CO_EVENT_EVENTFD 1
+#define CO_EVENT_KQUEUE 2
+#define CO_EVENT_PIPE 3
+
 // Apple has deprecated user contexts so we can't use them
 // on MacOS.  Linux still has them and there's an issue with
 // using setjmp/longjmp on Linux when running with LLVM
@@ -79,6 +91,9 @@
 #endif
 #define CO_POLL_MODE CO_POLL_POLL
 #define CO_TIMER_MODE CO_TIMER_EVENT
+#ifndef CO_EVENT_MODE
+#define CO_EVENT_MODE CO_EVENT_KQUEUE
+#endif
 #include <csetjmp>
 
 #elif defined(__linux__)
@@ -96,6 +111,9 @@
 #include <ucontext.h>
 #define CO_POLL_MODE CO_POLL_EPOLL // Change this line to disable epoll
 #define CO_TIMER_MODE CO_TIMER_TIMERFD // Change this line to use POSIX timer instead
+#ifndef CO_EVENT_MODE
+#define CO_EVENT_MODE CO_EVENT_EVENTFD
+#endif
 
 #elif defined(__QNX__) || defined(__QNXNTO__)
 // QNX configuration
@@ -108,6 +126,9 @@
 #endif
 #define CO_POLL_MODE CO_POLL_POLL
 #define CO_TIMER_MODE CO_TIMER_POSIX
+#ifndef CO_EVENT_MODE
+#define CO_EVENT_MODE CO_EVENT_PIPE
+#endif
 #else
 // Other OS, use the custom context switcher if available
 // or setjmp/longjmp if not.  The custom context switcher is only available
@@ -121,6 +142,9 @@
 #include <csetjmp>
 #define CO_POLL_MODE CO_POLL_POLL
 #define CO_TIMER_MODE CO_TIMER_POSIX // Use POSIX timer for other OSes
+#ifndef CO_EVENT_MODE
+#define CO_EVENT_MODE CO_EVENT_PIPE
+#endif
 #endif
 
 #include <poll.h>

--- a/http_client/main.cc
+++ b/http_client/main.cc
@@ -134,8 +134,8 @@ static size_t ReadContents(co::Coroutine *c, int fd, std::string &buffer,
     if (i < buffer.size()) {
       // Data remaining in buffer
       size_t nbytes = buffer.size() - i;
-      if (nbytes > length) {
-        nbytes = length;
+      if (nbytes > static_cast<size_t>(length)) {
+        nbytes = static_cast<size_t>(length);
       }
       if (write_to_output) {
         fwrite(&buffer[i], 1, nbytes, stdout);


### PR DESCRIPTION
## Summary

Adds QNX 8 (Neutrino) support to the coroutines library and, while doing so, refactors the cross-platform "event fd" abstraction so the portable pipe-based path is no longer a special case held together with a global mutex/lookup table. Pairs with the QNX port of subspace: https://github.com/dallison/subspace/pull/62.


### `co/context.S` — QNX support for the custom context switcher

The hand-written assembly defining `CoroutineMakeContext` / `CoroutineSwapContext` / `CoroutineGetContext` / `CoroutineSetContext` only declared its ELF directives under `#if defined(__linux__)`, so QNX builds hit `#error "Unknown OS"`. QNX uses ELF and the same GNU-as syntax as Linux, so the existing Linux branch is correct for it; just extend the gate to include `__QNX__` / `__QNXNTO__`. (`client/arm_crc32.S` in subspace is already structured the same way.)

### `co::EventFd` — self-contained portable event fd

The previous implementation hard-`#error`-ed on any platform that has neither macOS `kqueue` nor Linux `eventfd`. Replaced the standalone `NewEventFd` / `TriggerEvent` / `ClearEvent` / `CloseEventFd` static functions (which on the portable path required a global `unordered_map` + `std::mutex` to remember the write end of each pipe) with a self-contained `co::EventFd` struct:

- `poll_fd` — the fd to add to a poll/epoll set (read end on pipe, eventfd on Linux, kqueue on macOS).
- `trigger_fd` — the fd to write to in order to signal the event (write end on pipe, same as `poll_fd` on Linux/macOS).
- Member methods: `Trigger()`, `Clear()`, `Close()`, `IsValid()`, `Reset()`.
- Static factories: `EventFd::Create()` and `EventFd::CreateAbort()`.

This is functionally equivalent to `toolbelt::TriggerFd` from `cpp_toolbelt`, but is duplicated in `co/` to avoid the circular dependency that would otherwise be needed.

Every place that used to hold a raw event-fd `int` now holds an `EventFd`:

- `Coroutine::abort_fd_`
- `Coroutine::event_fd_` (was a `pollfd` in poll mode and the fd inside `yield_fd_` in epoll mode; now the `YieldedCoroutine yield_fd_` is populated from `event_fd_.poll_fd`).
- `CoroutineScheduler::interrupt_fd_` and `co_interrupt_fd_` — both modes now use the same type, so `GetInterruptFd()` collapses into a single non-`#ifdef`-ed implementation.

This also fixes a pre-existing leak: `~CoroutineScheduler` now closes `co_interrupt_fd_` (the original code only closed `interrupt_fd_`).

### `CO_EVENT_MODE` — selectable event-fd backend

To make the new code testable on Linux/macOS without needing a QNX host, added a `CO_EVENT_MODE` selector following the same pattern as `CO_POLL_MODE` / `CO_TIMER_MODE`:

```
CO_EVENT_EVENTFD - Linux eventfd            (default on Linux)
CO_EVENT_KQUEUE  - macOS kqueue/EVFILT_USER (default on macOS)
CO_EVENT_PIPE    - non-blocking pipe pair    (default on QNX/other)
```

`coroutine.cc` now dispatches all `EventFd` operations on `CO_EVENT_MODE` rather than `__APPLE__` / `__linux__` guards, and platform-specific includes (`<sys/event.h>`, `<sys/eventfd.h>`) are gated on the actual mode being used. Each platform branch in `coroutine.h` wraps its `#define CO_EVENT_MODE …` in `#ifndef CO_EVENT_MODE`, so the build can override the default, e.g.:

```
bazel test //co:coroutines_test --copt=-DCO_EVENT_MODE=3   # force pipe mode
```

This means the QNX (pipe) path now gets exercised every time someone runs the tests on Linux with that override, instead of only being reachable on a real QNX box.

### Existing QNX wiring this builds on

`co/coroutine.h` already has an explicit `__QNX__` / `__QNXNTO__` branch that selects:

- `CO_CTX_MODE = CO_CTX_CUSTOM` on x86_64/aarch64 (uses `context.S`, fixed by this PR).
- `CO_POLL_MODE = CO_POLL_POLL`.
- `CO_TIMER_MODE = CO_TIMER_POSIX` — already a portable POSIX-timer + pipe implementation, no changes needed.

This PR adds:

- `CO_EVENT_MODE = CO_EVENT_PIPE` to that QNX branch (and to the generic "other OS" fallback).

### Drive-by

- Bumped module version `3.2.1` → `3.3.0` in `MODULE.bazel`.
- Silenced a `-Wsign-compare` warning in `http_client/main.cc` (`size_t` vs `int` comparison inside a loop already gated on `length > 0`).

## Test plan

- [x] `bazel test //co:coroutines_test` on Linux with the default backend (`CO_EVENT_EVENTFD`).
- [x] `bazel test //co:coroutines_test --copt=-DCO_EVENT_MODE=3` on Linux to exercise the pipe-based portable path that QNX will use.
- [ ] `bazel test //...` on macOS to confirm no regression on the kqueue path.
- [ ] On a host with a real QNX toolchain (or via the subspace PR's toolchain once it lands): `qcc` build of `co/coroutine.cc` + `co/context.S` succeeds.
- [ ] On QNX: run `coroutines_test` and confirm the pipe-based event fd correctly wakes blocked coroutines and that `Trigger` / `Clear` are seen across context switches.
- [ ] Verify there is no fd leak when many coroutines are created and destroyed (e.g. `stress_test` in subspace) — should now be obvious from the destructor since each `EventFd` owns its own fds.

Made with [Cursor](https://cursor.com)